### PR TITLE
Add tester user groups, and Slack notifications 

### DIFF
--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -14,6 +14,8 @@ jobs:
   build-android:
     runs-on: self-hosted
     steps:
+      - run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Starting Android beta build"}' ${{secrets.SLACK_URL}}
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
         with:
@@ -29,6 +31,8 @@ jobs:
         with:
           name: android-build-files
           path: ./build/app/outputs/flutter-apk/app-release.apk
+      - run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Android beta build completed"}' ${{secrets.SLACK_URL}}
   deploy-android:
     needs: build-android
     runs-on: self-hosted
@@ -41,5 +45,7 @@ jobs:
         with:
           appId: ${{secrets.FIREBASE_APP_ID}}
           token: ${{secrets.FIREBASE_TOKEN}}
-          groups: testers
+          groups: alpha
           file: app-release.apk
+      - run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Android beta build deployed to beta testers"}' ${{secrets.SLACK_URL}}

--- a/.github/workflows/ios-beta.yml
+++ b/.github/workflows/ios-beta.yml
@@ -14,6 +14,8 @@ jobs:
   build-ios:
     runs-on: macos-latest
     steps:
+      - run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Starting iOS beta build"}' ${{secrets.SLACK_URL}}
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
         with:
@@ -29,6 +31,8 @@ jobs:
         with:
           name: ios-build-files
           path: /Users/runner/work/tommy/tommy/build/ios/iphoneos/Runner.app
+      - run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"iOS beta build completed"}' ${{secrets.SLACK_URL}}
   deploy-ios:
     needs: build-ios
     runs-on: self-hosted
@@ -41,5 +45,7 @@ jobs:
         with:
           appId: ${{secrets.FIREBASE_APP_ID}}
           token: ${{secrets.FIREBASE_TOKEN}}
-          groups: testers
+          groups: alpha
           file: Runner.app
+      - run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"iOS beta build deployed to beta testers"}' ${{secrets.SLACK_URL}}


### PR DESCRIPTION
This was mostly to test out the workflow end-to-end, and test the new Firebase test user groups.

The Slack bot is an extra touch because why not