### PR TITLE
TOM-34 generate the scripts for packaging and publishing products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,7 @@ app.*.map.json
 
 /lib/generated/
 
-/android/google_play.json
+android/*google_play.json
+android/*key.properties
+products/*
+!products/sample

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -19,6 +19,6 @@ platform :android do
   desc "Submit a new Beta Build to Google Play Store"
   lane :beta do
     gradle(task: 'assemble', build_type: 'Release')
-    upload_to_play_store(track: 'Promote')
+    upload_to_play_store(track: 'internal')
   end
 end

--- a/build-product.sh
+++ b/build-product.sh
@@ -82,6 +82,9 @@ else
                 bundle exec fastlane beta
                 cd ..
 
+                echo "Remove all changes in local directory ..."
+                git restore .
+
                 echo "All Done!!"
             fi
         fi

--- a/build-product.sh
+++ b/build-product.sh
@@ -65,14 +65,18 @@ else
             echo "Prepare credentials for Apple App Store "
             perl -pi -e 's/7W5L2XPVKS/'$developmentTeamId'/g' ios/Runner.xcodeproj/project.pbxproj
             perl -pi -e 's/Tommy/'$provisioningProfileSpecifier'/g' ios/Runner.xcodeproj/project.pbxproj
-            perl -pi -e 's/YOUR_APPLE_ID/'$appleIdToRelease'/g' ios/fastlane/Appfile
+            sed -i '' 's/YOUR_APPLE_ID/'$appleIdToRelease'/' ios/fastlane/Appfile
             perl -pi -e 's/YOUR_APPLE_APP_STORE_CONNECT_TEAM_ID/'$appleAppStoreConnectTeamID'/g' ios/fastlane/Appfile
             
             echo "Publish the App to Google Play Store Internal Testing"
-            cd android && bundle exec fastlane beta && cd ..
+            cd android
+            bundle exec fastlane beta
+            cd ..
 
             echo "Publish the App to Apple App TestFlight"
-            cd ios && bundle exec fastlane beta && cd ..
+            cd ios
+            bundle exec fastlane beta
+            cd ..
 
             echo "All Done!!"
         fi

--- a/build-product.sh
+++ b/build-product.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# pre-requirements for running this code:
+# 1. put all product related files into a folder with the name of your project and then put that folder into the products folder under root directory
+# 2. set up the iOS release certificate on your machine for the project
+# 3. make sure the content of YOUR_PROJECT_key.properties matches YOUR_PROJECT_release_key.keystore
+
+
+product=$1;
+echo "Build for Product: $product"
+
+if [ $product == "lojing" ] || [ $product == "internmatch" ]
+then
+    appName=`jq '.appName' products/$product/${product}_config.json | tr -d '"'`
+    bundleId=`jq '.bundleId' products/$product/${product}_config.json | tr -d '"'`
+    grpcUrl=`jq '.grpcUrl' products/$product/${product}_config.json | tr -d '"'`
+    grpcPort=`jq '.grpcPort' products/$product/${product}_config.json | tr -d '"'`
+    developmentTeamId=`jq '.developmentTeamId' products/$product/${product}_config.json | tr -d '"'`
+    provisioningProfileSpecifier=`jq '.provisioningProfileSpecifier' products/$product/${product}_config.json | tr -d '"'`
+    appleIdToRelease=`jq '.appleIdToRelease' products/$product/${product}_config.json | tr -d '"'`
+    # to get appleAppStoreConnectTeamID, visit https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/user/detail and look for contentProviderId
+    appleAppStoreConnectTeamID=`jq '.appleAppStoreConnectTeamID' products/$product/${product}_config.json | tr -d '"'`
+
+    if [ -z "$appName" ] || [ -z "$bundleId" ] || [ -z "$grpcUrl" ] || [ -z "$grpcPort" ] || [ -z "$developmentTeamId" ] || [ -z "$provisioningProfileSpecifier" ]  || [ -z "$appleIdToRelease" ] || [ -z "$appleAppStoreConnectTeamID" ]
+    then
+        echo `$product-config.json does not exist.`
+    else
+        arrayDirectoryName=(${bundleId//./ })
+        if [ ${#arrayDirectoryName[@]} != 3 ]
+        then
+            echo "Bundle id is in wrong format"
+        else
+            echo "Replace grpcUrl and grpcPort"
+            perl -pi -e 's/10.0.2.2/'$grpcUrl'/g' lib/projectenv.dart
+            perl -pi -e 's/5154/'$grpcPort'/g' lib/projectenv.dart
+
+            echo "Replace bundle id and package name"
+            perl -pi -e 's/life.genny.tommy/'$bundleId'/g' $(git ls-files -- . ':!:*build-product.sh')
+
+            echo "Move MainActivity.kt to the right package in /android/app/src/main/kotlin"
+            mkdir -p android/app/src/main/kotlin/${arrayDirectoryName[0]}/${arrayDirectoryName[1]}/${arrayDirectoryName[2]}
+            mv android/app/src/main/kotlin/life/genny/tommy/MainActivity.kt android/app/src/main/kotlin/${arrayDirectoryName[0]}/${arrayDirectoryName[1]}/${arrayDirectoryName[2]}/
+
+            echo "Replace app name"
+            perl -pi -e 's/tommy/'$appName'/g' android/app/src/main/AndroidManifest.xml
+            perl -pi -e 's/Tommy/'$appName'/g' ios/Runner/info.plist
+            perl -pi -e 's/tommy/'$appName'/g' ios/Runner/info.plist
+
+            echo "Prepare credentials for Google Play Store"
+            echo "Put google_play.json in android folder"
+            cp products/$product/${product}_google_play.json android/${product}_google_play.json
+            perl -pi -e 's/google_play.json/'${product}_google_play.json'/g' android/fastlane/Appfile
+            
+            echo "Put key.property in android folder"
+            cp products/$product/${product}_key.properties android/${product}_key.properties
+            perl -pi -e 's/key.properties/'${product}_key.properties'/g' android/app/build.gradle
+
+            echo "Put release-key.keystore in android/app folder"
+            cp products/$product/${product}_release_key.keystore android/${product}_krelease_key.keystore
+
+            echo "Prepare credentials for App App Store "
+            perl -pi -e 's/7W5L2XPVKS/'$developmentTeamId'/g' ios/Runner.xcodeproj/project.pbxproj
+            perl -pi -e 's/Tommy/'$provisioningProfileSpecifier'/g' ios/Runner.xcodeproj/project.pbxproj
+            perl -pi -e 's/YOUR_APPLE_ID/'$appleIdToRelease'/g' ios/fastlane/Appfile
+            perl -pi -e 's/YOUR_APPLE_APP_STORE_CONNECT_TEAM_ID/'$appleAppStoreConnectTeamID'/g' ios/fastlane/Appfile
+            
+            echo "Publish the App to Google Play Store Internal Testing"
+            cd android && bundle exec fastlane beta && cd ..
+
+            echo "Publish the App to Apple App TestFlight"
+            cd ios && bundle exec fastlane beta && cd ..
+
+            echo "All Done!!"
+        fi
+    fi
+else
+    echo "No project found! Please check your input, e.g, sh build-product.sh internmatch"
+fi
+

--- a/build-product.sh
+++ b/build-product.sh
@@ -9,8 +9,10 @@
 product=$1;
 echo "Build for Product: $product"
 
-if [ $product == "lojing" ] || [ $product == "internmatch" ]
+if [ -z "$product" ]
 then
+    echo "No project found! Please check your input, e.g, sh build-product.sh internmatch"
+else
     appName=`jq '.appName' products/$product/${product}_config.json | tr -d '"'`
     bundleId=`jq '.bundleId' products/$product/${product}_config.json | tr -d '"'`
     grpcUrl=`jq '.grpcUrl' products/$product/${product}_config.json | tr -d '"'`
@@ -42,7 +44,9 @@ then
             mv android/app/src/main/kotlin/life/genny/tommy/MainActivity.kt android/app/src/main/kotlin/${arrayDirectoryName[0]}/${arrayDirectoryName[1]}/${arrayDirectoryName[2]}/
 
             echo "Replace app name"
-            perl -pi -e 's/tommy/'$appName'/g' android/app/src/main/AndroidManifest.xml
+            perl -pi -e 's/android:label=\"tommy\"/android:label="'$appName'"/g' android/app/src/main/AndroidManifest.xml
+
+            
             perl -pi -e 's/Tommy/'$appName'/g' ios/Runner/info.plist
             perl -pi -e 's/tommy/'$appName'/g' ios/Runner/info.plist
 
@@ -56,9 +60,9 @@ then
             perl -pi -e 's/key.properties/'${product}_key.properties'/g' android/app/build.gradle
 
             echo "Put release-key.keystore in android/app folder"
-            cp products/$product/${product}_release_key.keystore android/${product}_krelease_key.keystore
+            cp products/$product/${product}_release_key.keystore android/app/${product}_krelease_key.keystore
 
-            echo "Prepare credentials for App App Store "
+            echo "Prepare credentials for Apple App Store "
             perl -pi -e 's/7W5L2XPVKS/'$developmentTeamId'/g' ios/Runner.xcodeproj/project.pbxproj
             perl -pi -e 's/Tommy/'$provisioningProfileSpecifier'/g' ios/Runner.xcodeproj/project.pbxproj
             perl -pi -e 's/YOUR_APPLE_ID/'$appleIdToRelease'/g' ios/fastlane/Appfile
@@ -73,7 +77,5 @@ then
             echo "All Done!!"
         fi
     fi
-else
-    echo "No project found! Please check your input, e.g, sh build-product.sh internmatch"
 fi
 

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,7 +1,7 @@
 app_identifier("life.genny.tommy") # The bundle identifier of your app
-apple_id("xiang.chen@gada.io") # Your Apple email address
+apple_id("YOUR_APPLE_ID") # Your Apple email address
 
-itc_team_id("125515106") # App Store Connect Team ID
+itc_team_id("YOUR_APP_STORE_CONNECT_TEAM_ID") # App Store Connect Team ID
 team_id("7W5L2XPVKS") # Developer Portal Team ID
 
 # For more information about the Appfile, see:

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,7 +1,7 @@
 app_identifier("life.genny.tommy") # The bundle identifier of your app
 apple_id("YOUR_APPLE_ID") # Your Apple email address
 
-itc_team_id("YOUR_APP_STORE_CONNECT_TEAM_ID") # App Store Connect Team ID
+itc_team_id("YOUR_APPLE_APP_STORE_CONNECT_TEAM_ID") # App Store Connect Team ID
 team_id("7W5L2XPVKS") # Developer Portal Team ID
 
 # For more information about the Appfile, see:

--- a/products/sample/sample_config.json
+++ b/products/sample/sample_config.json
@@ -1,0 +1,10 @@
+{
+  "appName": "Sample",
+  "bundleId": "life.genny.sample",
+  "grpcUrl": "sample.gada.io",
+  "grpcPort": "30299",
+  "developmentTeam": "DEVELOPMENT_TEAM_Sample",
+  "provisioningProfileSpecifier": "PROVISIONING_PROFILE_SPECIFIER_Sample",
+  "appleIdToRelease": "xxx@gada.io",
+  "appleAppStoreConnectTeamID": "125555666"
+}

--- a/products/sample/sample_google_play.json
+++ b/products/sample/sample_google_play.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "YOUR_PROJECT-177222",
+  "private_key_id": "5e3ae59a908_YOUR_PRIVATE_KEY_ID_86a5ab75",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIICVBEBgkqhki_YOUR_PRIVATE_KEY_aB2PWnFA82hvHj7o=\n-----END PRIVATE KEY-----\n",
+  "client_email": "gaservice@YOUR_PROJECT-177222.iam.gserviceaccount.com",
+  "client_id": "109093_YOUR_CLIENT_ID_1959",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gaservice%40YOUR_PROJECT-177222.iam.gserviceaccount.com"
+}

--- a/products/sample/sample_key.properties
+++ b/products/sample/sample_key.properties
@@ -1,0 +1,4 @@
+storePassword=YOUR_STORE_PASSWORD
+keyPassword=YOUR_KEY_PASSWORD
+keyAlias=YOUR_KEY_ALIAS
+storeFile=YOUR_PROJECT_release_key.keystore

--- a/products/sample/sample_release_key.keystore
+++ b/products/sample/sample_release_key.keystore
@@ -1,0 +1,2 @@
+THIS IS THE FILE YOU GENEREATED WITH COMMAND:
+keytool -genkey -v -keystore YOUR_PROJECT_release_key.keystore -alias YOUR_KEY_ALIAS -keyalg RSA -keysize 2048 -validity 10000


### PR DESCRIPTION
Set up a script to package and publish releases to products. Simply by running `sh build-product.sh lojing`,  will trigger:
1. replace all bundle in and package names
2. replace grpcUrl and grpc port for each product
3. replace credentials for each store
4. use fastlane to package and release